### PR TITLE
Remove the unused 'import os' from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 __author__ = 'seanfitz'
 
-import os
 from setuptools import setup
 
 setup(


### PR DESCRIPTION
The `os` module seems to be unused at the moment in `setup.py`, so this pull request just removes the import.

Hope you're having a great day! :)