### PR TITLE
Add Python 3 support

### DIFF
--- a/adapt/entity_tagger.py
+++ b/adapt/entity_tagger.py
@@ -1,4 +1,5 @@
 from adapt.tools.text.trie import Trie
+from past.builtins import xrange
 
 __author__ = 'seanfitz'
 

--- a/adapt/entity_tagger.py
+++ b/adapt/entity_tagger.py
@@ -58,7 +58,7 @@ class EntityTagger(object):
                 for regex_entity in self.regex_entities:
                     match = regex_entity.match(part)
                     groups = match.groupdict() if match else {}
-                    for key in groups.keys():
+                    for key in list(groups):
                         match_str = groups.get(key)
                         local_trie.insert(match_str, key)
                 sub_tagger = EntityTagger(local_trie, self.tokenizer, max_tokens=self.max_tokens)

--- a/adapt/entity_tagger.py
+++ b/adapt/entity_tagger.py
@@ -1,5 +1,5 @@
 from adapt.tools.text.trie import Trie
-from past.builtins import xrange
+from six.moves import xrange
 
 __author__ = 'seanfitz'
 

--- a/adapt/expander.py
+++ b/adapt/expander.py
@@ -1,3 +1,5 @@
+from past.builtins import xrange
+
 __author__ = 'seanfitz'
 
 

--- a/adapt/expander.py
+++ b/adapt/expander.py
@@ -1,4 +1,4 @@
-from past.builtins import xrange
+from six.moves import xrange
 
 __author__ = 'seanfitz'
 

--- a/adapt/expander.py
+++ b/adapt/expander.py
@@ -26,7 +26,7 @@ class SimpleGraph(object):
         return self.adjacency_lists.get(a, set())
 
     def vertex_set(self):
-        return self.adjacency_lists.keys()
+        return list(self.adjacency_lists)
 
 
 def bronk(r, p, x, graph):
@@ -128,7 +128,7 @@ class BronKerboschExpander(object):
                     tag
                 ]
 
-        for clique in get_cliques(entities.keys(), graph):
+        for clique in get_cliques(list(entities), graph):
             result = []
             for entity_name in clique:
                 start_token = int(entity_name.split("-")[0])

--- a/adapt/tools/text/trie.py
+++ b/adapt/tools/text/trie.py
@@ -42,7 +42,7 @@ class TrieNode(object):
         potential_confidence = float(index - edit_distance + (max_edit_distance - edit_distance)) / \
                                (float(index) + (max_edit_distance - edit_distance)) if index + max_edit_distance - edit_distance > 0 else 0.0
         if edit_distance < max_edit_distance and potential_confidence > match_threshold:
-            for child in self.children.keys():
+            for child in list(self.children):
                 if index >= len(iterable) or child != iterable[index]:
                     # substitution
                     for result in self.children[child]\

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 argparse==1.2.1
 pyee==0.1.0
+future==0.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 argparse==1.2.1
 pyee==0.1.0
-wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 argparse==1.2.1
 pyee==0.1.0
-future==0.15.2
+six==1.10.0

--- a/test/IntentEngineTest.py
+++ b/test/IntentEngineTest.py
@@ -14,7 +14,7 @@ class IntentEngineTests(unittest.TestCase):
         try:
             self.engine.register_intent_parser("NOTAPARSER")
             assert "Did not fail to register invalid intent parser" and False
-        except ValueError, e:
+        except ValueError as e:
             pass
         parser = IntentBuilder("Intent").build()
         self.engine.register_intent_parser(parser)


### PR DESCRIPTION
As discussed in issue #2, here's the pull request that brings in Python 3 compatibility.

Note that I expect TravisCI run to fail on this, since `future` [supports Python 3.3 and later](http://python-future.org/faq.html#which-versions-of-python-does-python-future-support). If 3.2 is required, we could swap the `future` package for the `six` package, that one should be compatible with nearly every Python version.