### PR TITLE
Cleaner doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Getting Started
 ===============
-To take a dependency on Adapt, it's recommended to use virtualenv and pip to
-install source from github.
+To install all dependencies for Adapt, it's recommended to use virtualenv and
+pip to install the source from github.
 
 
     $ virtualenv myvirtualenv
@@ -23,10 +23,11 @@ structured intent that can then be invoked programatically.
 Intent Modelling
 ================
 In this context, an Intent is an action the system should perform. In the
-context of Pandora, we’ll define two actions: List Stations, and Select Station
-(aka start playback)
+context of Pandora, we will define two actions: "List Stations", and "Select
+Station" (aka start to play).
 
-With the Adapt intent builder:
+We are using the Adapt intent builder to define first the "List Stations"
+intent, with a single requirement of a "Browse Music Command" entity.
 
 ~~~ python
 list_stations_intent = IntentBuilder('pandora:list_stations')\
@@ -34,8 +35,8 @@ list_stations_intent = IntentBuilder('pandora:list_stations')\
     .build()
 ~~~
 
-For the above, we are describing a “List Stations” intent, which has a single
-requirement of a “Browse Music Command” entity.
+The more complex "Select Station" intent requires a "Listen Command", a
+"Pandora Station" and optionally a "Music Keyword" entity.
 
 ~~~ python
 play_music_command = IntentBuilder('pandora:select_station')\
@@ -45,24 +46,22 @@ play_music_command = IntentBuilder('pandora:select_station')\
     .build()
 ~~~
 
-For the above, we are describing a “Select Station” (aka start playback)
-intent, which requires a “Listen Command” entity, a “Pandora Station”, and
-optionally a “Music Keyword” entity.
-
 Entities
 ========
 
-Entities are a named value. Examples include:
-Blink 182 is an Artist  
-The Big Bang Theory is a Television Show  
-Play is a Listen Command  
-Song(s) is a Music Keyword  
+Entities are a named value, and work as the building blocks of the intents.
+Some examples could be:
+  
+"Blink 182" is an Artist  
+"The Big Bang Theory" is a Television Show  
+"Play" is a Listen Command  
+"Song(s)" is a Music Keyword  
 
-For my Pandora implementation, there is a static set of vocabulary for the
-Browse Music Command, Listen Command, and Music Keyword (defined by me, a
-native english speaker and all-around good guy). Pandora Station entities are
-populated via a "List Stations" API call to Pandora. Here’s what the vocabulary
-registration looks like.
+For the Pandora example implementation, there is a static set of vocabulary for
+the "Browse Music" Command, "Listen" Command, and "Music Keyword" (defined by
+me, a native english speaker and all-around good guy). Pandora Station entities
+are populated via a "List Stations" API call to Pandora. Here’s what the
+vocabulary registration looks like.
 
 
 ~~~ python

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Getting Started
 ===============
-To take a dependency on Adapt, it's recommended to use virtualenv and pip to install source from github.
+To take a dependency on Adapt, it's recommended to use virtualenv and pip to
+install source from github.
 
 
     $ virtualenv myvirtualenv
@@ -10,70 +11,83 @@ To take a dependency on Adapt, it's recommended to use virtualenv and pip to ins
 
 Examples
 ========
-Executable examples can be found in the [examples folder](https://github.com/MycroftAI/adapt/tree/master/examples).
+Executable examples can be found in the
+[examples folder](https://github.com/MycroftAI/adapt/tree/master/examples).
 
 Overview
 ==================
-The Adapt Intent Parser is a flexible and extensible intent definition and determination framework. It is intended to parse natural language text into a structured intent that can then be invoked programatically.
+The Adapt Intent Parser is a flexible and extensible intent definition and
+determination framework. It is intended to parse natural language text into a
+structured intent that can then be invoked programatically.
 
 Intent Modelling
 ================
-In this context, an Intent is an action the system should perform. In the context of Pandora, we’ll define two actions: List Stations, and Select Station (aka start playback)
+In this context, an Intent is an action the system should perform. In the
+context of Pandora, we’ll define two actions: List Stations, and Select Station
+(aka start playback)
 
 With the Adapt intent builder:
 
-    list_stations_intent = IntentBuilder('pandora:list_stations')\
-        .require('Browse Music Command')\
-        .build()
+~~~ python
+list_stations_intent = IntentBuilder('pandora:list_stations')\
+    .require('Browse Music Command')\
+    .build()
+~~~
 
+For the above, we are describing a “List Stations” intent, which has a single
+requirement of a “Browse Music Command” entity.
 
-For the above, we are describing a “List Stations” intent, which has a single requirement of a “Browse Music Command” entity.
+~~~ python
+play_music_command = IntentBuilder('pandora:select_station')\
+    .require('Listen Command')\
+    .require('Pandora Station')\
+    .optionally('Music Keyword')\
+    .build()
+~~~
 
-
-    play_music_command = IntentBuilder('pandora:select_station')\
-        .require('Listen Command')\
-        .require('Pandora Station')\
-        .optionally('Music Keyword')\
-        .build()
-
-
-
-For the above, we are describing a “Select Station” (aka start playback) intent, which requires a “Listen Command” entity, a “Pandora Station”, and optionally a “Music Keyword” entity.
+For the above, we are describing a “Select Station” (aka start playback)
+intent, which requires a “Listen Command” entity, a “Pandora Station”, and
+optionally a “Music Keyword” entity.
 
 Entities
 ========
 
 Entities are a named value. Examples include:
-Blink 182 is an Artist
-The Big Bang Theory is a Television Show
-Play is a Listen Command
-Song(s) is a Music Keyword
+Blink 182 is an Artist  
+The Big Bang Theory is a Television Show  
+Play is a Listen Command  
+Song(s) is a Music Keyword  
 
-For my Pandora implementation, there is a static set of vocabulary for the Browse Music Command, Listen Command, and Music Keyword (defined by me, a native english speaker and all-around good guy). Pandora Station entities are populated via a "List Stations" API call to Pandora. Here’s what the vocabulary registration looks like.
+For my Pandora implementation, there is a static set of vocabulary for the
+Browse Music Command, Listen Command, and Music Keyword (defined by me, a
+native english speaker and all-around good guy). Pandora Station entities are
+populated via a "List Stations" API call to Pandora. Here’s what the vocabulary
+registration looks like.
 
 
-    def register_vocab(entity_type, entity_value):
-        # a tiny bit of code 
+~~~ python
+def register_vocab(entity_type, entity_value):
+    # a tiny bit of code 
 
-    def register_pandora_vocab(emitter):
-        for v in ["stations"]:
-            register_vocab('Browse Music Command', v)
+def register_pandora_vocab(emitter):
+    for v in ["stations"]:
+        register_vocab('Browse Music Command', v)
 
-        for v in ["play", "listen", "hear"]:
-            register_vocab('Listen Command', v)
+    for v in ["play", "listen", "hear"]:
+        register_vocab('Listen Command', v)
 
-        for v in ["music", "radio"]:
-            register_vocab('Music Keyword', v)
+    for v in ["music", "radio"]:
+        register_vocab('Music Keyword', v)
 
-        for v in ["Pandora"]:
-            register_vocab('Plugin Name', v)
+    for v in ["Pandora"]:
+        register_vocab('Plugin Name', v)
 
-        station_name_regex = re.compile(r"(.*) Radio")
-        p = get_pandora()
-        for station in p.stations:
-            m = station_name_regex.match(station.get('stationName'))
-            if not m:
-                continue
-            for match in m.groups():
-                register_vocab('Pandora Station', match)
-
+    station_name_regex = re.compile(r"(.*) Radio")
+    p = get_pandora()
+    for station in p.stations:
+        m = station_name_regex.match(station.get('stationName'))
+        if not m:
+            continue
+        for match in m.groups():
+            register_vocab('Pandora Station', match)
+~~~

--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
-Getting Started
-===============
+# Getting Started
+
 To install all dependencies for Adapt, it's recommended to use virtualenv and
 pip to install the source from github.
 
+~~~
+$ virtualenv myvirtualenv
+$ . myvirtualenv/bin/activate
+$ pip install -e git+https://github.com/mycroftai/adapt#egg=adapt-parser
+~~~
 
-    $ virtualenv myvirtualenv
-    $ . myvirtualenv/bin/activate
-    $ pip install -e git+https://github.com/mycroftai/adapt#egg=adapt-parser
 
+## Examples
 
-Examples
-========
 Executable examples can be found in the
 [examples folder](https://github.com/MycroftAI/adapt/tree/master/examples).
 
-Overview
-==================
+
+## Overview
+
 The Adapt Intent Parser is a flexible and extensible intent definition and
 determination framework. It is intended to parse natural language text into a
 structured intent that can then be invoked programatically.
 
-Intent Modelling
-================
+## Intent Modelling
+
 In this context, an Intent is an action the system should perform. In the
 context of Pandora, we will define two actions: "List Stations", and "Select
 Station" (aka start to play).
@@ -46,8 +48,7 @@ play_music_command = IntentBuilder('pandora:select_station')\
     .build()
 ~~~
 
-Entities
-========
+## Entities
 
 Entities are a named value, and work as the building blocks of the intents.
 Some examples could be:


### PR DESCRIPTION
I propose a small clean-up of the readme file, to use better the possibilities of Github (syntax highlighting, proper use of the title levels, a few formatting issues). Feel free to look on [my branch](https://github.com/baudren/adapt/tree/cleaner_doc) to see the resulting look.

I also took the liberty of reformulating a few passages that were confusing to me - as I am not a native English speaker, please feel free to ignore them.

Finally, I also kept a fixed line length of 80, as I find it is nicer to read.

Would be nice to add the Travis badge, too!