### PR TITLE
declare dependencies correctly in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
     keywords = "natural language processing",
     url = "https://github.com/MycroftAI/adapt",
     packages = ["adapt", "adapt.tools", "adapt.tools.text"],
-    dependency_links = [
+
+    install_requires = [
         "pyee==0.1.0",
         "six==1.10.0"
     ]


### PR DESCRIPTION
`dependency_links` is for specifying URLs which should be searched to
satisfy the dependencies. The actual dependencies should be listed in
`install_requires` so that they're pulled in on `pip install`.

See `https://pythonhosted.org/setuptools/setuptools.html#developer-s-guide`