### PR TITLE
Pulling requirements.txt into test-requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ python:
   - "3.4"
   - "3.5"
 install:
-  - pip install -r requirements.txt
   - pip install -r test-requirements.txt
 script: python run_tests.py --fail-on-error

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
+-r requirements.txt
 xmlrunner==1.7.7


### PR DESCRIPTION
This will allow one to run 'pip install -r test-requirements.txt' rather then having to run pip install for both "requirements.txt and test-requirements.txt".