### PR TITLE
 pyee version 0.1.0 conflicts with mycroft, is threre a reason for th…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 argparse==1.2.1
-pyee==0.1.0
+pyee==1.0.1
 six==1.10.0


### PR DESCRIPTION
…is? There are only releases for 1.0.1 and 1.0.2 on pypi.python.org. Somehow, you can still pip install 0.1.0 though...