### PR TITLE
Fix max_frames causing IndexError

### DIFF
--- a/adapt/context.py
+++ b/adapt/context.py
@@ -109,7 +109,7 @@ class ContextManager(object):
         Returns:
             list: a list of entities
         """
-        if not max_frames:
+        if not max_frames or max_frames > len(self.frame_stack):
             max_frames = len(self.frame_stack)
 
         missing_entities = list(missing_entities)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name = "adapt-parser",
-    version = "0.3.0",
+    version = "0.3.1",
     author = "Sean Fitzgerald",
     author_email = "sean@fitzgeralds.me",
     description = ("A text-to-intent parsing framework."),

--- a/test/ContextManagerTest.py
+++ b/test/ContextManagerTest.py
@@ -15,6 +15,15 @@ class ContextManagerTest(unittest.TestCase):
         assert len(context) == 1
         assert context[0].get('confidence') == 0.5
 
+    def testInjectRetrieveContextMaxFrames(self):
+        manager = ContextManager()
+        entity = {'key': 'The hitchhikers guide to the galaxy',
+                  'data': 'Book', 'confidence': 1.0}
+        manager.inject_context(entity)
+        context = manager.get_context(max_frames=2)
+        assert len(context) == 1
+        assert context[0].get('confidence') == 0.5
+
     def testNewContextNoMetadataResultsInNewFrame(self):
         manager = ContextManager()
         entity1 = {'key': 'Grapes of Wrath', 'data': 'Book', 'confidence': 1.0}


### PR DESCRIPTION
Minimal test case and limitation of `max_frames` in `ContextManager.get()`