### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 argparse==1.2.1
-pyee==1.0.1
+pyee>=1.0.1
 six==1.10.0


### PR DESCRIPTION
This changes the requirements to allow any version of pyee greater than 1.0.1. I've been working on creating a debian package for mycroft, and in order to do so I need to use pyee 3.0.3. I've tested both adapt and mycroft with 3.0.3, and both work fine. I'm also fine with pinning this to something like >=1.0.1 and <= 3.0.3 in case you're concerned about future pyee changes breaking current adapt functionality.