### PR TITLE
Add support to IntentBuilder() for no names

### DIFF
--- a/adapt/intent.py
+++ b/adapt/intent.py
@@ -199,12 +199,12 @@ class IntentBuilder(object):
     Example:
         IntentBuilder("Intent").requires("A").one_of("C","D").optional("G").build()
     """
-    def __init__(self, intent_name):
+    def __init__(self, intent_name=None):
         """
         Constructor
 
         Args:
-            intent_name(str): the name of the intents that this parser parses/validates
+            intent_name(str, optional): the name of the intents that this parser parses/validates
         """
         self.at_least_one = []
         self.requires = []


### PR DESCRIPTION
This allows creation of intents with no name.  The names are not used
internally within Adapt, but this is particularly useful within other
ecosystems such as Mycroft Skills which can automatically name the intent
appropriately from context.