### PR TITLE
Remove __author__ field

### DIFF
--- a/adapt/__init__.py
+++ b/adapt/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-__author__ = 'seanfitz'
 import os
 if os.path.exists('README.md'):
   import codecs

--- a/adapt/context.py
+++ b/adapt/context.py
@@ -22,8 +22,6 @@ Notes:
 """
 from six.moves import xrange
 
-__author__ = "seanfitz, Art McGee"
-
 
 class ContextManagerFrame(object):
     """

--- a/adapt/engine.py
+++ b/adapt/engine.py
@@ -21,8 +21,6 @@ from adapt.parser import Parser
 from adapt.tools.text.tokenizer import EnglishTokenizer
 from adapt.tools.text.trie import Trie
 
-__author__ = 'seanfitz'
-
 
 class IntentDeterminationEngine(pyee.EventEmitter):
     """

--- a/adapt/entity_tagger.py
+++ b/adapt/entity_tagger.py
@@ -16,8 +16,6 @@
 from adapt.tools.text.trie import Trie
 from six.moves import xrange
 
-__author__ = 'seanfitz'
-
 
 class EntityTagger(object):
     """

--- a/adapt/expander.py
+++ b/adapt/expander.py
@@ -15,8 +15,6 @@
 
 from six.moves import xrange
 
-__author__ = 'seanfitz'
-
 
 class SimpleGraph(object):
     """This class is to graph connected nodes

--- a/adapt/intent.py
+++ b/adapt/intent.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 #
 
-__author__ = 'seanfitz'
-
 CLIENT_ENTITY_NAME = 'Client'
 
 

--- a/adapt/parser.py
+++ b/adapt/parser.py
@@ -18,8 +18,6 @@ import time
 from adapt.expander import BronKerboschExpander
 from adapt.tools.text.trie import Trie
 
-__author__ = 'seanfitz'
-
 
 class Parser(pyee.EventEmitter):
     """

--- a/adapt/tools/__init__.py
+++ b/adapt/tools/__init__.py
@@ -13,5 +13,4 @@
 # limitations under the License.
 #
 
-__author__ = "seanfitz"
 __doc__=""

--- a/adapt/tools/text/__init__.py
+++ b/adapt/tools/text/__init__.py
@@ -13,4 +13,3 @@
 # limitations under the License.
 #
 
-__author__ = 'seanfitz'

--- a/adapt/tools/text/tokenizer.py
+++ b/adapt/tools/text/tokenizer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-__author__ = 'seanfitz'
 import re
 regex_letter_number = r"[a-zA-Z0-9]"
 regex_not_letter_number = r"[^a-zA-Z0-9]"

--- a/adapt/tools/text/trie.py
+++ b/adapt/tools/text/trie.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 #
 
-__author__ = 'seanfitz'
-
 
 class TrieNode(object):
     def __init__(self, data=None, is_terminal=False):

--- a/examples/multi_domain_intent_parser.py
+++ b/examples/multi_domain_intent_parser.py
@@ -1,4 +1,3 @@
-__author__ = 'the-kid89'
 """
 A sample program that uses multiple intents and disambiguates by
 intent confidence

--- a/examples/multi_intent_parser.py
+++ b/examples/multi_intent_parser.py
@@ -1,4 +1,3 @@
-__author__ = 'seanfitz'
 """
 A sample program that uses multiple intents and disambiguates by
 intent confidence

--- a/examples/regex_intent_parser.py
+++ b/examples/regex_intent_parser.py
@@ -1,4 +1,3 @@
-__author__ = 'seanfitz'
 """
 A sample intent that uses a regular expression entity to
 extract location from a query

--- a/examples/single_intent_parser.py
+++ b/examples/single_intent_parser.py
@@ -1,4 +1,3 @@
-__author__ = 'seanfitz'
 """
 A sample intent that uses a fixed vocabulary to extract entities for an intent
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-__author__ = 'seanfitz'
 
 from setuptools import setup
 

--- a/test/ContextManagerIntegrationTest.py
+++ b/test/ContextManagerIntegrationTest.py
@@ -17,8 +17,6 @@ from adapt.context import ContextManager
 from adapt.engine import IntentDeterminationEngine
 from adapt.intent import IntentBuilder
 
-__author__ = "seanfitz"
-
 import unittest
 
 

--- a/test/DomainIntentEngineTest.py
+++ b/test/DomainIntentEngineTest.py
@@ -20,8 +20,6 @@ from adapt.entity_tagger import EntityTagger
 from adapt.tools.text.tokenizer import EnglishTokenizer
 from adapt.tools.text.trie import Trie
 
-__author__ = 'seanfitz'
-
 
 class TokenizerTests(unittest.TestCase):
     """All tests related to the DomainIntentDeterminationEngine."""

--- a/test/EntityExpanderTest.py
+++ b/test/EntityExpanderTest.py
@@ -18,8 +18,6 @@ from adapt.expander import BronKerboschExpander
 from adapt.tools.text.tokenizer import EnglishTokenizer
 from adapt.tools.text.trie import Trie
 
-__author__ = 'seanfitz'
-
 import unittest
 
 

--- a/test/EntityTaggerTest.py
+++ b/test/EntityTaggerTest.py
@@ -19,8 +19,6 @@ from adapt.tools.text.tokenizer import EnglishTokenizer
 from adapt.tools.text.trie import Trie
 import re
 
-__author__ = 'seanfitz'
-
 
 class EntityTaggerTest(unittest.TestCase):
 

--- a/test/IntentEngineTest.py
+++ b/test/IntentEngineTest.py
@@ -17,8 +17,6 @@ import unittest
 from adapt.engine import IntentDeterminationEngine
 from adapt.intent import IntentBuilder
 
-__author__ = 'seanfitz'
-
 
 class IntentEngineTests(unittest.TestCase):
     def setUp(self):

--- a/test/IntentTest.py
+++ b/test/IntentTest.py
@@ -21,8 +21,6 @@ from adapt.intent import IntentBuilder
 from adapt.tools.text.tokenizer import EnglishTokenizer
 from adapt.tools.text.trie import Trie
 
-__author__ = 'seanfitz'
-
 
 class IntentTest(unittest.TestCase):
 

--- a/test/TrieTest.py
+++ b/test/TrieTest.py
@@ -16,8 +16,6 @@
 import unittest
 from adapt.tools.text.trie import Trie
 
-__author__ = 'seanfitz'
-
 
 class TrieTest(unittest.TestCase):
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -13,4 +13,3 @@
 # limitations under the License.
 #
 
-__author__ = 'seanfitz'


### PR DESCRIPTION
Removes the `__author__` field from the files.

@clusterfudge: you talked about owner-files as a replacement. What are these exactly? They seem to be hard to google.

