### PR TITLE
Remove python 3.3 and add 3.6-8 from travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install -r requirements.txt
   - pip install -r test-requirements.txt


### PR DESCRIPTION
Update the travis config to run on more modern python. This also removes Python 3.3 since it's no longer available.

