### PR TITLE
Update broken documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ def register_pandora_vocab(emitter):
 Learn More
 ========
 
-Further documentation can be found at https://adapt.mycroft.ai
+Further documentation can be found at https://mycroft-ai.gitbook.io/docs/mycroft-technologies/adapt


### PR DESCRIPTION
* Description of what the PR does:
The link https://adapt.mycroft.ai is broken, it appears https://mycroft-ai.gitbook.io/docs/mycroft-technologies/adapt is the correct link for Adapt documentation now.

* Description of how to validate or test this PR
Click the link 🤷🏻‍♂️

* Whether you have signed a CLA (Contributor Licensing Agreement)
No