### PR TITLE
chore(engine.py): correct include_tags's docstring

### DIFF
--- a/adapt/engine.py
+++ b/adapt/engine.py
@@ -108,7 +108,7 @@ class IntentDeterminationEngine(pyee.BaseEventEmitter):
 
         Args:
             utterance(str): an ascii or unicode string representing natural language speech
-            include_tags(list): includes the parsed tags (including position and confidence)
+            include_tags(bool): includes the parsed tags (including position and confidence)
                 as part of result
             context_manager(list): a context manager to provide context to the utterance
             num_results(int): a maximum number of results to be returned.


### PR DESCRIPTION
* Description of what the PR does, such as fixes # {issue number}
Corrects `IntentDeterminationEngine.determine_intent`'s `include_tags` parameter documentation.

* Description of how to validate or test this PR
Compare former doc with actual usage: parameter has `False` as default and is only used in a `if include_tags` conditional.
* Whether you have signed a CLA (Contributor Licensing Agreement)
:+1: 

