### PR TITLE
Issues/114

### DIFF
--- a/adapt/intent.py
+++ b/adapt/intent.py
@@ -186,7 +186,7 @@ class Intent(object):
             if optional_tag in local_tags:
                 local_tags.remove(optional_tag)
             used_tags.append(optional_tag)
-            intent_confidence += 1.0
+            intent_confidence += tag_confidence
 
         total_confidence = (intent_confidence / len(tags) * parse_weight) if tags else 0.0
 

--- a/adapt/intent.py
+++ b/adapt/intent.py
@@ -139,7 +139,9 @@ class Intent(object):
 
         Args:
             tags(list): Tags and Entities used for validation
-            parse_weight(float): ?
+            parse_weight(float): The weight associate to the parse result,
+                as indicated by the parser. This is influenced by a parser
+                that uses edit distance or context.
 
         Returns:
             intent, tags: Returns intent and tags used by the intent on

--- a/adapt/intent.py
+++ b/adapt/intent.py
@@ -186,7 +186,7 @@ class Intent(object):
             used_tags.append(optional_tag)
             intent_confidence += 1.0
 
-        total_confidence = intent_confidence / len(tags) * parse_weight if tags else 0.0
+        total_confidence = (intent_confidence / len(tags) * parse_weight) if tags else 0.0
 
         target_client, canonical_form, parse_weight = find_first_tag(local_tags, CLIENT_ENTITY_NAME)
 

--- a/test/IntentEngineTest.py
+++ b/test/IntentEngineTest.py
@@ -165,3 +165,14 @@ class IntentEngineTests(unittest.TestCase):
         self.engine.drop_regex_entity(match_func=matcher)
         assert len(self.engine._regex_strings) == 2
         assert len(self.engine.regular_expressions_entities) == 2
+    def testEmptyTags(self):
+        # Validates https://github.com/MycroftAI/adapt/issues/114
+        engine = IntentDeterminationEngine()
+        engine.register_entity("Kevin",
+                               "who")  # same problem if several entities
+        builder = IntentBuilder("Buddies")
+        builder.optionally("who")  # same problem if several entity types
+        engine.register_intent_parser(builder.build())
+
+        intents = [i for i in engine.determine_intent("Julien is a friend")]
+        assert len(intents) == 0


### PR DESCRIPTION
Fixes #114 

Also uncovered a bug where a method parameter ( Intent.validate_with_tags(self, tags, `confidence`) ) was being overridden internally. The fix includes better variable names for confidence and parser_weight as appropriate, and does not break any existing tests.

I've added an explicit test that fails in the example provided in #114 , and that test passes with this change.

CLA Signed
