### PR TITLE
Fix storing regex as string when cleaned

### DIFF
--- a/adapt/engine.py
+++ b/adapt/engine.py
@@ -232,9 +232,12 @@ class IntentDeterminationEngine(pyee.EventEmitter):
                    if match_func(r)]
         matching_patterns = [r.pattern for r in matches]
 
-        self.regular_expressions_entities = [
-            r for r in self.regular_expressions_entities if r not in matches
+        matches = [
+            r for r in self.regular_expressions_entities if r in matches
         ]
+        for match in matches:
+            self.regular_expressions_entities.remove(match)
+
         self._regex_strings = {
             r for r in self._regex_strings if r not in matching_patterns
         }

--- a/adapt/engine.py
+++ b/adapt/engine.py
@@ -235,9 +235,9 @@ class IntentDeterminationEngine(pyee.EventEmitter):
         self.regular_expressions_entities = [
             r for r in self.regular_expressions_entities if r not in matches
         ]
-        self._regex_strings = [
+        self._regex_strings = {
             r for r in self._regex_strings if r not in matching_patterns
-        ]
+        }
 
         return len(matches) != 0
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def required(requirements_file):
 
 setup(
     name="adapt-parser",
-    version="0.4.1",
+    version="0.4.2",
     author="Sean Fitzgerald",
     author_email="sean@fitzgeralds.me",
     description=("A text-to-intent parsing framework."),

--- a/test/IntentEngineTest.py
+++ b/test/IntentEngineTest.py
@@ -179,6 +179,23 @@ class IntentEngineTests(unittest.TestCase):
         self.engine.register_regex_entity(r"the cool (?P<thing>.*)")
         assert len(self.engine.regular_expressions_entities) == 1
 
+    def testUsingOfRemovedRegexp(self):
+        self.engine.register_regex_entity(r"the cool (?P<thing>.*)")
+        parser = IntentBuilder("Intent").require("thing").build()
+        self.engine.register_intent_parser(parser)
+
+        def matcher(regexp):
+            """Matcher for all match groups defined for SkillB"""
+            match_groups = regexp.groupindex.keys()
+            return any([k.startswith('thing') for k in match_groups])
+
+        self.engine.drop_regex_entity(match_func=matcher)
+        assert len(self.engine.regular_expressions_entities) == 0
+
+        utterance = "the cool cat"
+        intents = [match for match in self.engine.determine_intent(utterance)]
+        assert len(intents) == 0
+
     def testEmptyTags(self):
         # Validates https://github.com/MycroftAI/adapt/issues/114
         engine = IntentDeterminationEngine()

--- a/test/IntentEngineTest.py
+++ b/test/IntentEngineTest.py
@@ -165,6 +165,20 @@ class IntentEngineTests(unittest.TestCase):
         self.engine.drop_regex_entity(match_func=matcher)
         assert len(self.engine._regex_strings) == 2
         assert len(self.engine.regular_expressions_entities) == 2
+
+    def testAddingOfRemovedRegexp(self):
+        self.engine.register_regex_entity(r"the cool (?P<thing>.*)")
+
+        def matcher(regexp):
+            """Matcher for all match groups defined for SkillB"""
+            match_groups = regexp.groupindex.keys()
+            return any([k.startswith('thing') for k in match_groups])
+
+        self.engine.drop_regex_entity(match_func=matcher)
+        assert len(self.engine.regular_expressions_entities) == 0
+        self.engine.register_regex_entity(r"the cool (?P<thing>.*)")
+        assert len(self.engine.regular_expressions_entities) == 1
+
     def testEmptyTags(self):
         # Validates https://github.com/MycroftAI/adapt/issues/114
         engine = IntentDeterminationEngine()


### PR DESCRIPTION
Removing regexp entity changed the type of the `_regex_strings` member to a list instead of a set. resolves #134 

