### PR TITLE
Allow building adapt with loose requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ def required(requirements_file):
     base_dir = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(base_dir, requirements_file), 'r') as f:
         requirements = f.read().splitlines()
+
+        if 'MYCROFT_LOOSE_REQUIREMENTS' in os.environ:
+            print('USING LOOSE REQUIREMENTS!')
+            requirements = [r.replace('==', '>=') for r in requirements]
         return [pkg for pkg in requirements
                 if pkg.strip() and not pkg.startswith("#")]
 


### PR DESCRIPTION
* Description of what the PR does, such as fixes # {issue number}

The adapt equivalent of https://github.com/MycroftAI/mycroft-core/commit/ff50c4b5ecffc0d81822d8efab404054ca52b492.
This allows Linux distributions to ship adapt even though they have newer versions than specified in requirements.txt.
Since distributions have to make sure for themselves that their packages work anyway, and this only happens when explicitely specified, this is safe to do. The user has to figure out problems themselves when they use this.

* Description of how to validate or test this PR

In a clean virtual environment, run `MYCROFT_LOOSE_REQUIREMENTS=1 python3 setup.py install` and verify if the _newest_ version of all dependencies are installed, rather than the pinned version.

* Whether you have signed a CLA (Contributor Licensing Agreement)

Yes
