### PR TITLE
Fix name of LICENSE file in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 README.md
-LICENCE.md
+LICENSE.md
 requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def required(requirements_file):
 
 setup(
     name="adapt-parser",
-    version="0.5.0",
+    version="0.5.1",
     author="Sean Fitzgerald",
     author_email="sean@fitzgeralds.me",
     description=("A text-to-intent parsing framework."),


### PR DESCRIPTION
This was preventing it being included in PyPI packages.

Fixes #124