### PR TITLE
Fix mycroft-core PR generation 

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,9 +39,12 @@ jobs:
 
   tag-release-if-needed:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
     steps:
     - uses: actions/checkout@v2
-    - name: Tag release
+    - id: tag
+      name: Tag release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TWINE_USERNAME: __token__
@@ -57,7 +60,7 @@ jobs:
           twine check dist/*
           twine upload dist/*
           echo "Package pushed to PyPI. Prepare for mycroft-core PR."
-          echo "::set-env name=VERSION::$VERSION"
+          echo "::set-output name=version::$VERSION"
         fi
 
   publish:
@@ -78,8 +81,7 @@ jobs:
 
   update-mycroft-core:
     runs-on: ubuntu-latest
-    if: ${{ env.VERSION == *"."* }}
-    needs: publish
+    needs: [publish, tag-release-if-needed]
     steps:
     - uses: actions/checkout@v2
       with: 
@@ -89,19 +91,26 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if [[ $VERSION != *"-"* ]]; then
-          echo No pre-release suffix detected.
-          git config user.name mycroft-devs
-          git config user.email devs@mycroft.ai
+        VERSION=${{needs.tag-release-if-needed.outputs.version}}
+        if [[ $VERSION != *"."* ]]; then
+          echo "Not a valid version number."
+          exit 1
+        elif [[ $VERSION == *"-"* ]]; then
+          echo "Pre-release suffix detected. Not pushing to mycroft-core."
+        else
           sed -E "s/adapt-parser==[0-9]+\.[0-9]+\.[0-9]+/adapt-parser==$VERSION/" requirements/requirements.txt > tmp-requirements.txt
           mv tmp-requirements.txt requirements/requirements.txt
+          echo "ADAPT_VERSION=$VERSION" >> $GITHUB_ENV
         fi
 
     - name: Create Pull Request
+      if: ${{ env.ADAPT_VERSION }}
       uses: peter-evans/create-pull-request@v3
       with:
-        commit-message: Update Adapt to v$VERSION
+        token: ${{ secrets.BOT_TOKEN }}
+        push-to-fork: mycroft-adapt-bot/mycroft-core
+        commit-message: Update Adapt to v${{ env.ADAPT_VERSION }}
         branch: feature/update-adapt
         delete-branch: true
-        title: Update Adapt to v$VERSION
+        title: Update Adapt to v${{ env.ADAPT_VERSION }}
         body: Automated update from mycroftai/adapt.


### PR DESCRIPTION
### Description
- Fixes PR #141
- Uses `outputs` to share data between jobs
- Uses new syntax for setting environment variable to share data between steps within the `update-mycroft-core` job
- Uses a dedicated bot account to create the PR's to minimize security risk of using a Personal Access Token within Github Secrets. 

#### The longer story
The method I used to assign the `VERSION` environment variable has been [deprecated due to a security vulnerability](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). This switches to the new syntax [outlined here](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable). Even with that change, the environment variable doesn't seem to be accessible between jobs, only between steps within the same job. 

During my reading, I also discovered that PR's generated directly by Github Actions apparently cannot trigger other Github Actions. So the use of a 3rd account is a recommended way of working around this:
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

### How to test
See Action output here:
- [All working and PR created](https://github.com/krisgesling/adapt/actions/runs/1260486441)
- [If the VERSION variable doesn't get set we don't create a PR](https://github.com/krisgesling/adapt/actions/runs/1260501001)
- [If we don't publish to PyPI then we don't create a PR](https://github.com/krisgesling/adapt/actions/runs/1260523891)

### CLA
- [x] Yes

