### PR TITLE
Remove duplicate PyPI publishing job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,25 +63,9 @@ jobs:
           echo "::set-output name=version::$VERSION"
         fi
 
-  publish:
-    runs-on: ubuntu-latest
-    if: contains(github.ref, '/tags/release')
-    needs: build
-    steps:
-    - uses: actions/checkout@v2
-    - name: Push to pypi
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        pip install twine wheel
-        python setup.py sdist bdist_wheel
-        twine check dist/*
-        twine upload dist/*
-
   update-mycroft-core:
     runs-on: ubuntu-latest
-    needs: [publish, tag-release-if-needed]
+    needs: tag-release-if-needed
     steps:
     - uses: actions/checkout@v2
       with: 


### PR DESCRIPTION
### Description
The PyPI publishing got embedded in the tagging job and I somehow failed to see this when adding the mycroft-core PR creation job.

Hence the `publish` job would always fail, and a PR will never get created.

This removes that job and makes `update-mycroft-core` rely solely on `tag-release-if-needed`.

### Testing
I haven't yet done another round of testing on my fork. This seems pretty clear though.


### CLA
- [x] Yes

