### PR TITLE
Making the python installer work in a Windows environment.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ __author__ = 'seanfitz'
 import os
 from setuptools import setup
 
-with open("README.md", "r", encoding=utf_8) as fh:
+with open("README.md", "r", encoding="utf_8") as fh:
     long_description = fh.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ __author__ = 'seanfitz'
 import os
 from setuptools import setup
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding=utf_8) as fh:
     long_description = fh.read()
 
 


### PR DESCRIPTION
If an encoding type is not specified, it'll try to use the system default. In the case of Windows, that's cp1252.
When the installer tries to run with that encoding. It spews this decode error:

`
  File "C:\Users\Michael\PythonEnvironments\Adapt\src\adapt-parser\setup.py", line 22, in <module>
    long_description = fh.read()
  File "C:\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 2157: character maps to <undefined>
`

This just makes the installer work on Windows.